### PR TITLE
Pass host as address

### DIFF
--- a/src/clojure/data/alpha/replicant/server/prepl.clj
+++ b/src/clojure/data/alpha/replicant/server/prepl.clj
@@ -68,7 +68,8 @@
    (assert host ":host argument required and expects a string")
    (println "Replicant server listening on" port "...")
    (let [server-socket (server/start-server 
-                        {:port   port,
+                        {:address host
+                         :port   port,
                          :name   server-name,
                          :accept 'clojure.data.alpha.replicant.server.prepl/rds-prepl
                          :args   [(or cache (create-default-cache))]


### PR DESCRIPTION
The `host` parameter was passed to the `start` function (even there is an assertion on it), but it was not used on the code. This parameter is needed in case the server is run inside a docker container for instance, in which typically we would use `0.0.0.0` instead of the default `localhost`.

Note also that the version of the function without arguments will just pass `nil`, causing the assertion to trigger, which I guess it is not the intended behavior (although I did not modify it, just in case it was intended)